### PR TITLE
refactor: utilise assertions

### DIFF
--- a/src/main/java/membot/commands/Command.java
+++ b/src/main/java/membot/commands/Command.java
@@ -74,12 +74,13 @@ public abstract class Command {
             case EVENT:
                 return new EventCommand(input, ui);
             default:
-                // Should not reach here
-                throw new InvalidCommandException(String.format("%s is not a valid command!", inputArr[0]));
+                assert false : "Unknown command";
             }
         } catch (IllegalArgumentException e) {
             throw new InvalidCommandException(String.format("%s is not a valid command!", inputArr[0]));
         }
+
+        throw new InvalidCommandException(String.format("%s is not a valid command!", inputArr[0]));
     }
 
     /**

--- a/src/main/java/membot/model/Task.java
+++ b/src/main/java/membot/model/Task.java
@@ -113,9 +113,10 @@ public abstract class Task {
         case COMPLETED:
             return "X";
         default:
-            // Should not reach here
-            return "?";
+            assert false : "Available Task status are: NEW, COMPLETED";
         }
+
+        return "?";
     }
 
     /**
@@ -174,7 +175,7 @@ public abstract class Task {
                         new String(endDateTime, StandardCharsets.UTF_8));
                 break;
             default:
-                break;
+                assert false : "Unknown Task type";
             }
 
             restoredTask.setStatus(TaskStatus.valueOf(new String(status, StandardCharsets.UTF_8)));


### PR DESCRIPTION
Assertions: utilise `assert` for empty `default` clauses in `switch-case`

`default` clauses throw an error or return arbitruary values.

Using `assert` is more readable and ensures that errors are caught in the future when the `switch-case` statements are not updated.

Let's:
- ensure that `default` clauses are updated when new values are added for the `switch-case` statements in the future