### PR TITLE
feat: add `Sort` command for date, status, title, type

### DIFF
--- a/src/main/java/membot/commands/Command.java
+++ b/src/main/java/membot/commands/Command.java
@@ -73,6 +73,8 @@ public abstract class Command {
                 return new DeadlineCommand(input, ui);
             case EVENT:
                 return new EventCommand(input, ui);
+            case SORT:
+                return new SortCommand(input, ui);
             default:
                 assert false : "Unknown command";
             }
@@ -81,15 +83,6 @@ public abstract class Command {
         }
 
         throw new InvalidCommandException(String.format("%s is not a valid command!", inputArr[0]));
-    }
-
-    /**
-     * Returns true if the <code>Command</code> causes the application to exit, false otherwise.
-     *
-     * @return True if the <code>Command</code> causes the application to exit, false otherwise.
-     */
-    public boolean isExit() {
-        return this.isExit;
     }
 
     /**
@@ -111,5 +104,6 @@ enum CommandType {
     TODO,
     DEADLINE,
     EVENT,
+    SORT,
     BYE
 }

--- a/src/main/java/membot/commands/SortCommand.java
+++ b/src/main/java/membot/commands/SortCommand.java
@@ -31,37 +31,37 @@ public class SortCommand extends Command {
 
         try {
             switch (SortOption.valueOf(this.input.split(" ")[1].toUpperCase())) {
-                case TITLE:
-                    Task.sort(Comparator.comparing(Task::getTitle));
-                    break;
-                case DATE:
-                    Task.sort((t1, t2) -> {
-                        LocalDateTime t1DT;
-                        LocalDateTime t2DT;
+            case TITLE:
+                Task.sort(Comparator.comparing(Task::getTitle));
+                break;
+            case DATE:
+                Task.sort((t1, t2) -> {
+                    LocalDateTime t1DT;
+                    LocalDateTime t2DT;
 
-                        try {
-                            t1DT = DateTimeParser.parse(t1.getDeadline());
-                        } catch (DateTimeParseException e) {
-                            return 1;
-                        }
+                    try {
+                        t1DT = DateTimeParser.parse(t1.getDeadline());
+                    } catch (DateTimeParseException e) {
+                        return 1;
+                    }
 
-                        try {
-                            t2DT = DateTimeParser.parse(t2.getDeadline());
-                        } catch (DateTimeParseException e) {
-                            return -1;
-                        }
+                    try {
+                        t2DT = DateTimeParser.parse(t2.getDeadline());
+                    } catch (DateTimeParseException e) {
+                        return -1;
+                    }
 
-                        return t1DT.compareTo(t2DT);
-                    });
-                    break;
-                case STATUS:
-                    Task.sort(Comparator.comparing(Task::printStatus));
-                    break;
-                case TYPE:
-                    Task.sort(Comparator.comparing(Task::getTaskType));
-                    break;
-                default:
-                    assert false : "Available options are: date, status, title, type";
+                    return t1DT.compareTo(t2DT);
+                });
+                break;
+            case STATUS:
+                Task.sort(Comparator.comparing(Task::printStatus));
+                break;
+            case TYPE:
+                Task.sort(Comparator.comparing(Task::getTaskType));
+                break;
+            default:
+                assert false : "Available options are: date, status, title, type";
             }
         } catch (IllegalArgumentException e) {
             this.ui.printlnError(

--- a/src/main/java/membot/commands/SortCommand.java
+++ b/src/main/java/membot/commands/SortCommand.java
@@ -1,0 +1,85 @@
+package membot.commands;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.Comparator;
+
+import membot.model.Task;
+import membot.utils.DateTimeParser;
+import membot.utils.InputValidator;
+import membot.view.Printable;
+
+/**
+ * Represents a command which sorts the <code>Task</code> list based on the sort
+ * option specified.
+ */
+public class SortCommand extends Command {
+    protected SortCommand(String input, Printable ui) {
+        super(input, ui);
+    }
+
+    @Override
+    public void execute() {
+        if (!InputValidator.isSingleInputValid(this.input, false, false)) {
+            this.ui.printlnError(
+                    "Invalid Syntax: \"sort [option]\"",
+                    "",
+                    "Example: \"sort date\""
+            );
+            return;
+        }
+
+        try {
+            switch (SortOption.valueOf(this.input.split(" ")[1].toUpperCase())) {
+                case TITLE:
+                    Task.sort(Comparator.comparing(Task::getTitle));
+                    break;
+                case DATE:
+                    Task.sort((t1, t2) -> {
+                        LocalDateTime t1DT;
+                        LocalDateTime t2DT;
+
+                        try {
+                            t1DT = DateTimeParser.parse(t1.getDeadline());
+                        } catch (DateTimeParseException e) {
+                            return 1;
+                        }
+
+                        try {
+                            t2DT = DateTimeParser.parse(t2.getDeadline());
+                        } catch (DateTimeParseException e) {
+                            return -1;
+                        }
+
+                        return t1DT.compareTo(t2DT);
+                    });
+                    break;
+                case STATUS:
+                    Task.sort(Comparator.comparing(Task::printStatus));
+                    break;
+                case TYPE:
+                    Task.sort(Comparator.comparing(Task::getTaskType));
+                    break;
+                default:
+                    assert false : "Available options are: date, status, title, type";
+            }
+        } catch (IllegalArgumentException e) {
+            this.ui.printlnError(
+                    "Invalid sort option!",
+                    "Available options are: date, status, title, type"
+            );
+            this.ui.printSeparator();
+            return;
+        }
+
+        new ListCommand(this.ui).execute();
+        this.ui.printSeparator();
+    }
+}
+
+enum SortOption {
+    DATE,
+    STATUS,
+    TITLE,
+    TYPE
+}

--- a/src/main/java/membot/model/Task.java
+++ b/src/main/java/membot/model/Task.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.stream.Collectors;
 
@@ -103,7 +104,12 @@ public abstract class Task {
         return Task.tasks.get(id - 1).toString();
     }
 
-    private String printStatus() {
+    /**
+     * Prints out the <code>Task</code> status.
+     *
+     * @return The <code>Task</code> status.
+     */
+    public String printStatus() {
         switch (this.status) {
         case NEW:
             return " ";
@@ -191,6 +197,24 @@ public abstract class Task {
     }
 
     /**
+     * Sorts the current list of <code>Task</code> with a specified <code>Comparator</code>.
+     *
+     * @param c <code>Comparator</code> used to sort the <code>Task</code> list.
+     */
+    public static void sort(Comparator<? super Task> c) {
+        Task.tasks.sort(c);
+    }
+
+    /**
+     * Retrieves the <code>Task</code> title.
+     *
+     * @return Title of the task.
+     */
+    public String getTitle() {
+        return this.title;
+    }
+
+    /**
      * Returns the <code>Task</code> type.
      *
      * @return The <code>Task</code> type.
@@ -234,8 +258,3 @@ enum TaskStatus {
     COMPLETED
 }
 
-enum TaskType {
-    TODO,
-    DEADLINE,
-    EVENT
-}

--- a/src/main/java/membot/model/TaskType.java
+++ b/src/main/java/membot/model/TaskType.java
@@ -1,0 +1,10 @@
+package membot.model;
+
+/**
+ * Represents the available <code>Task</code> types.
+ */
+public enum TaskType {
+    TODO,
+    DEADLINE,
+    EVENT
+}


### PR DESCRIPTION
This PR implements a sorting feature to `Membot`! With this PR, we have a new `sort` command which can currently sort the `Task` list based on `date`, `status`, `title`, `type`.

Example usage: `sort date` to sort the `Task` based on their deadlines (only for `Deadline` tasks).